### PR TITLE
Error on repeated 'delete' clicks

### DIFF
--- a/dashboard/utils.py
+++ b/dashboard/utils.py
@@ -205,6 +205,10 @@ def update_blacklist(scan_name, comment=None, blacklist_file=None, study_name=No
             cl_file.write('{}\t{}\n'.format(scan_name, comment))
         return True
 
+    if index is None:
+        # No entry found and no comment to add, exit early and do nothing.
+        return True
+
     # Otherwise, either update a comment or delete existing entry if
     # comment wasnt given
     if comment:

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -217,6 +217,9 @@ class TestUpdateBlacklist(unittest.TestCase):
         with patch("__builtin__.open", blacklist_mock):
             utils.update_blacklist(self.scan_name, None, study_name=self.study)
 
+        assert blacklist_mock().write.call_count == 0
+        assert blacklist_mock().writelines.call_count == 0
+
     def test_removes_entry_when_None_or_empty_string_given_as_comment(self,
             mock_get_contents, mock_find_metadata):
 

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -204,6 +204,19 @@ class TestUpdateBlacklist(unittest.TestCase):
 
         blacklist_mock().write.assert_called_once_with(new_line)
 
+    def test_deleting_scan_not_in_blacklist_does_nothing(self, mock_get_contents,
+            mock_find_metadata):
+        # Clicking delete multiple times very quickly was causing an
+        # exception when 'del lines[None]' tried to run after the first time
+        existing_contents = ["some_scan\ttrunacted series\n"]
+
+        mock_find_metadata.return_value = self.blacklist_file
+        mock_get_contents.return_value = existing_contents
+
+        blacklist_mock = mock_open()
+        with patch("__builtin__.open", blacklist_mock):
+            utils.update_blacklist(self.scan_name, None, study_name=self.study)
+
     def test_removes_entry_when_None_or_empty_string_given_as_comment(self,
             mock_get_contents, mock_find_metadata):
 


### PR DESCRIPTION
Fixed at least part of the problem with 'false' being inserted as a database comment when the user clicks the 'delete entry' button repeatedly very quickly.