### PR TITLE
Last minute github API related bug fixes

### DIFF
--- a/config.py
+++ b/config.py
@@ -53,7 +53,11 @@ OAUTH_CREDENTIALS = {'github': {'id': os.environ.get('OAUTH_CLIENT_GITHUB'),
 # Github config, needed for issues
 GITHUB_OWNER = os.environ.get('GITHUB_ISSUES_OWNER')
 GITHUB_REPO = os.environ.get('GITHUB_ISSUES_REPO')
-GITHUB_PUBLIC = os.environ.get('GITHUB_ISSUES_PUBLIC') or True
+GITHUB_PUBLIC = os.environ.get('GITHUB_ISSUES_PUBLIC')
+if GITHUB_PUBLIC is not None and GITHUB_PUBLIC.lower() == 'false':
+    GITHUB_PUBLIC = False
+else:
+    GITHUB_PUBLIC = True
 
 DISPLAY_METRICS = {'phantom': {'t1': ['c1', 'c2', 'c3', 'c4'],
                               'dti': ['AVENyqratio', 'AVE Ave.radpixshift', 'AVE Ave.colpixshift', 'aveSNR_dwi'],

--- a/dashboard/oauth.py
+++ b/dashboard/oauth.py
@@ -41,7 +41,7 @@ class OAuthSignIn(object):
         return self.providers[provider_name]
 
 class GithubSignIn(OAuthSignIn):
-    str_rnd = None
+
     def __init__(self):
         super(GithubSignIn, self).__init__('github')
 
@@ -62,14 +62,14 @@ class GithubSignIn(OAuthSignIn):
         return rnd
 
     def authorize(self):
-        self.str_rnd = self.random_string()
+        session['str_rnd'] = self.random_string()
         if GITHUB_PUBLIC:
             app_scope='user public_repo'
         else:
             app_scope = 'user repo'
         return redirect(self.service.get_authorize_url(
             scope=app_scope,
-            state=self.str_rnd)
+            state=session['str_rnd'])
             )
 
     def callback(self):
@@ -80,7 +80,7 @@ class GithubSignIn(OAuthSignIn):
             returned_state = request.args['state']
         except:
             returned_state = None
-        if not returned_state == self.str_rnd:
+        if not returned_state == session['str_rnd']:
             return None, None
 
         oauth_session = self.service.get_auth_session(

--- a/dashboard/views.py
+++ b/dashboard/views.py
@@ -307,7 +307,14 @@ def timepoint(study_id, timepoint_id):
     except KeyError:
         github_issues = None
     else:
-        github_issues = utils.search_issues(token, timepoint.name)
+        try:
+            github_issues = utils.search_issues(token, timepoint.name)
+        except:
+            flash("Github issue access failed. Please contact an admin if "
+                    "this issue persists.")
+            logger.error("Can't search github issues, user {} received "
+                    "access denied.".format(user))
+            github_issues = None
 
     empty_form = EmptySessionForm()
     findings_form = IncidentalFindingsForm()
@@ -914,7 +921,8 @@ def oauth_callback(provider):
     access_token, user_info = oauth.callback()
 
     if access_token is None:
-        flash('Authentication failed.')
+        flash('Authentication failed. Please contact an admin if '
+                'this problem is persistent')
         return redirect(url_for('login'))
 
     if provider == 'github':


### PR DESCRIPTION
- The fact that the real server is multithreaded meant oauth login was failing sporadically because the 'str_rnd' wasn't persistent. I've temporarily fixed this by moving it into the flask session for the user, but it should probably be in the database later for security reasons. Might also be good to permanently store the user token there.
- The 'GITHUB_PUBLIC' setting was being incorrectly read and always set to True, which made private repo issues unreadable. This is fixed now.