### PR TITLE
Updated dashboard to allow RA filtering by site

### DIFF
--- a/dashboard/models.py
+++ b/dashboard/models.py
@@ -544,8 +544,16 @@ class Study(db.Model):
     def get_staff_contacts(self):
         return [su.user for su in self.users if su.kimel_contact]
 
-    def get_RAs(self):
-        return [su.user for su in self.users if su.study_RA]
+    def get_RAs(self, site=None):
+        if site:
+            # Get all users who are an RA for this specific site or
+            # an RA for the whole study
+            RAs = [su.user for su in self.users
+                    if su.study_RA and (not su.site or su.site == site)]
+        else:
+            # Get all RAs for the study
+            RAs = [su.user for su in self.users if su.study_RA]
+        return RAs
 
     def get_QCers(self):
         return [su.user for su in self.users if su.does_qc]
@@ -1313,6 +1321,7 @@ class StudyUser(db.Model):
             nullable=False, primary_key=True)
     user_id = db.Column('user_id', db.Integer, db.ForeignKey('users.id'),
             nullable=False, primary_key=True)
+    site = db.Column('site_only', db.String(32), db.ForeignKey('sites.name'))
     is_admin = db.Column('is_admin', db.Boolean, default=False)
     primary_contact = db.Column('primary_contact', db.Boolean, default=False)
     kimel_contact = db.Column('kimel_contact', db.Boolean, default=False)

--- a/dashboard/monitors.py
+++ b/dashboard/monitors.py
@@ -110,7 +110,8 @@ def monitor_redcap_import(name, num, users=None, study=None):
 
     if not users:
         users = db_study.get_staff_contacts()
-        users.extend(db_study.get_RAs())
+        site = session.timepoint.site.name
+        users.extend(db_study.get_RAs(site=site))
         if not users:
             raise MonitorException("No users found to receive redcap import "
                     "notifications for {}".format(session))


### PR DESCRIPTION
Now we can restrict redcap missing emails on a site by site basis!

I've already added all the OPT RA emails to the database, so if this is merged afterwards I just have to add them to the study_user table with the site filled in and restart the server for the changes to take place. Currently it will just be us and the RAs getting them though, do we still need to add PIs to the list at some point?