### PR TITLE
Needed to update StudyUser primary key

### DIFF
--- a/dashboard/models.py
+++ b/dashboard/models.py
@@ -1337,7 +1337,8 @@ class StudyUser(db.Model):
             nullable=False, primary_key=True)
     user_id = db.Column('user_id', db.Integer, db.ForeignKey('users.id'),
             nullable=False, primary_key=True)
-    site = db.Column('site_only', db.String(32), db.ForeignKey('sites.name'))
+    site = db.Column('site_only', db.String(32), db.ForeignKey('sites.name'),
+            primary_key=True)
     is_admin = db.Column('is_admin', db.Boolean, default=False)
     primary_contact = db.Column('primary_contact', db.Boolean, default=False)
     kimel_contact = db.Column('kimel_contact', db.Boolean, default=False)


### PR DESCRIPTION
RAs for second sites (e.g. UP2, CU2) were not being recognized because StudyUser was only ever returning one unique study_id/user_id pair. 