### PR TITLE
Add basic task file management

### DIFF
--- a/dashboard/models.py
+++ b/dashboard/models.py
@@ -876,6 +876,7 @@ class Session(db.Model):
             back_populates='session', cascade='all, delete')
     redcap_record = db.relationship('SessionRedcap', back_populates='session',
             uselist=False, cascade='all, delete')
+    task_files = db.relationship('TaskFile', cascade='all, delete')
 
     def __init__(self, name, num, date=None, signed_off=False, reviewer_id=None,
             review_date=None):
@@ -1007,6 +1008,21 @@ class Session(db.Model):
     def save(self):
         db.session.add(self)
         db.session.commit()
+
+    def add_task(self, file_path, name=None):
+        for item in self.task_files:
+            if file_path == item.file_path:
+                return item
+        new_task = TaskFile(self.name, self.num, file_path, file_name=name)
+        self.task_files.append(new_task)
+        try:
+            self.save()
+        except Exception as e:
+            logger.error("Unable to add task file {}. Reason: {}".format(
+                    file_path, e))
+            db.session.rollback()
+            return None
+        return new_task
 
     def __repr__(self):
         return "<Session {}, {}>".format(self.name, self.num)
@@ -1326,6 +1342,34 @@ class Metrictype(db.Model):
 
     def __repr__(self):
         return('<MetricType {}>'.format(self.name))
+
+class TaskFile(db.Model):
+    __tablename__ = 'session_tasks'
+
+    id = db.Column('id', db.Integer, primary_key=True)
+    timepoint = db.Column('timepoint', db.String(64), nullable=False)
+    repeat = db.Column('repeat', db.Integer, nullable=False)
+    file_name = db.Column('task_fname', db.String(256), nullable=False)
+    file_path = db.Column('task_file_path', db.String(2048), nullable=False)
+
+    session = db.relationship('Session', uselist=False,
+            back_populates='task_files')
+
+    __table_args__ = (ForeignKeyConstraint(['timepoint', 'repeat'],
+            ['sessions.name', 'sessions.num']),
+            UniqueConstraint(file_path))
+
+    def __init__(self, timepoint, repeat, file_path, file_name=None):
+        self.timepoint = timepoint
+        self.repeat = repeat
+        self.file_path = file_path
+        if not file_name:
+            self.file_name = os.path.basename(self.file_path)
+        else:
+            self.file_name = file_name
+
+    def __repr__(self):
+        return "<TaskFile {}>".format(self.file_path)
 
 
 ################################################################################

--- a/dashboard/templates/timepoint/sessions/main.html
+++ b/dashboard/templates/timepoint/sessions/main.html
@@ -20,6 +20,10 @@
 {% block body_content %}
     {% include 'timepoint/sessions/review_status.html' %}
 
+    {% if session.task_files %}
+      {% include 'timepoint/sessions/task_files.html' %}
+    {% endif %}
+
     {% if session.redcap_record %}
       {% include 'timepoint/sessions/redcap_report.html' %}
     {% endif %}

--- a/dashboard/templates/timepoint/sessions/task_files.html
+++ b/dashboard/templates/timepoint/sessions/task_files.html
@@ -1,0 +1,8 @@
+<div class="task-files">
+  <span class="section-subheader">Task Files</span>
+  <div class="well">
+    {% for task in session.task_files %}
+        <div>{{ task.file_path }}</div>
+    {% endfor %}
+  </div>
+</div>


### PR DESCRIPTION
This adds task files to the database and displays a list of task files found for each session on the subject's page of the dashboard.

This query must be run after merging to update the database schema:
```sql
create table session_tasks(
    id serial primary key, 
    timepoint varchar(64) not null,
    repeat integer not null,
    task_fname varchar(256) not null,
    task_file_path varchar(2048) not null,
    foreign key(timepoint, repeat) references sessions(name, num),
    unique(task_file_path));
create index on session_tasks(timepoint, repeat);
```

And the corresponded datman pull request should be merged in too.