### PR TITLE
Added a wrapper to retrieve timepoints

### DIFF
--- a/dashboard/queries.py
+++ b/dashboard/queries.py
@@ -36,6 +36,12 @@ def get_session(name, num):
     """
     return Session.query.get((name, num))
 
+def get_timepoint(name):
+    """
+    Used by datman. Return one timepoint or None
+    """
+    return Timepoint.query.get(name)
+
 
 def find_sessions(search_str):
     """


### PR DESCRIPTION
Using the search bar's fuzzy search was causing problems with dm_qc_report, so I added  a very silly function just for exact match with timepoints.