### PR TITLE
Increase column size for bids session

### DIFF
--- a/dashboard/models.py
+++ b/dashboard/models.py
@@ -627,7 +627,7 @@ class Timepoint(db.Model):
 
     name = db.Column('name', db.String(64), primary_key=True)
     bids_name = db.Column('bids_name', db.Text)
-    bids_session = db.Column('bids_sess', db.String(2))
+    bids_session = db.Column('bids_sess', db.String(48))
     site_id = db.Column('site', db.String(32), db.ForeignKey('sites.name'),
             nullable=False)
     is_phantom = db.Column('is_phantom', db.Boolean, nullable=False,


### PR DESCRIPTION
Need column widths of 3 or more for prelapse session numbers. Making it 48 in case we ever just want to use a whole word or anything 