### PR TITLE
[FIX] - QC notifications now handled by monitors interface

### DIFF
--- a/dashboard/models.py
+++ b/dashboard/models.py
@@ -25,7 +25,8 @@ from psycopg2.tz import FixedOffsetTimezone
 
 from dashboard import db, TZ_OFFSET, utils
 from dashboard.emails import (account_request_email, account_activation_email,
-                              account_rejection_email, qc_notification_email)
+                              account_rejection_email)
+from .monitors import monitor_qc_needed
 from .exceptions import InvalidDataException
 from datman import scanid, header_checks
 
@@ -378,7 +379,7 @@ class Study(db.Model):
         if self.email_qc:
             not_qcd = [t.name for t in self.timepoints.all() if not
                        t.is_qcd()]
-            [qc_notification_email(u, self.id, timepoint.name, not_qcd) for
+            [monitor_qc_needed(u, self.id, timepoint.name, not_qcd) for
              u in self.get_QCers()]
 
         return timepoint

--- a/dashboard/monitors.py
+++ b/dashboard/monitors.py
@@ -17,7 +17,8 @@ from datetime import datetime, timedelta
 
 from dashboard import scheduler
 from .models import Session, User
-from .emails import missing_session_data_email, missing_redcap_email, qc_notification_email
+from .emails import (missing_session_data_email,
+                     missing_redcap_email, qc_notification_email
 from .exceptions import MonitorException
 
 logger = logging.getLogger(__name__)

--- a/dashboard/monitors.py
+++ b/dashboard/monitors.py
@@ -17,7 +17,7 @@ from datetime import datetime, timedelta
 
 from dashboard import scheduler
 from .models import Session, User
-from .emails import missing_session_data_email, missing_redcap_email
+from .emails import missing_session_data_email, missing_redcap_email, qc_notification_email
 from .exceptions import MonitorException
 
 logger = logging.getLogger(__name__)
@@ -162,3 +162,17 @@ def check_redcap(name, num, recipients=None):
     missing_redcap_email(str(session),
                          session.get_study().id,
                          dest_emails=recipients)
+
+
+def monitor_qc_needed(user, study, current_tp, remain_tp):
+    """
+    Adds an instant 'monitor' for notifying users of needed QC
+    Args:
+        user (Models.User): User object
+        study (str): Study name
+        current_tp (str): New timepoint needing QC
+        remain_tp (:obj:`list` of :obj:`str`): Timepoints still requiring QC
+    """
+
+    args = [user, study, current_tp, remain_tp]
+    add_monitor(qc_notification_email, args)


### PR DESCRIPTION
# Issue being fixed
- qc notification emails were failing to pass through due to SMTP errors, clients are not configured to send emails - must be done server-side or through the monitors.add_monitor interface.

# Fix implementation
- models.py now longer directly handles emails and instead interfaces with monitors.py which handles scheduling. 