### PR TITLE
[ENH] Add automated session downloading

### DIFF
--- a/config/__init__.py
+++ b/config/__init__.py
@@ -4,3 +4,4 @@ from .misc import *
 from .oauth import *
 from .scheduler import *
 from .logging import *
+from .cluster import *

--- a/config/cluster.py
+++ b/config/cluster.py
@@ -13,7 +13,7 @@ SUBMIT_OPTIONS = os.environ.get("DASHBOARD_QSUBMIT_OPTIONS") or "--chdir=/tmp/"
 SUBMIT_SCRIPTS = (
     os.environ.get("DASHBOARD_QSUBMIT_SCRIPTS") or
     os.path.join(
-        os.path.dirname(os.path.realpath(__name__)),
-        'dashboard/queue_jobs'
+        os.path.dirname(os.path.realpath(__file__)),
+        '../dashboard/queue_jobs'
         )
     )

--- a/config/cluster.py
+++ b/config/cluster.py
@@ -7,3 +7,13 @@ SUBMIT_COMMAND = os.environ.get("DASHBOARD_QSUBMIT_CMD") or "sbatch"
 
 # Options to always set during submission (e.g. QOS)
 SUBMIT_OPTIONS = os.environ.get("DASHBOARD_QSUBMIT_OPTIONS") or ""
+
+# Job script location. If changed from dashboard/queue_jobs, the folder
+# must contain scripts matching the names of those in the original folder.
+SUBMIT_SCRIPTS = (
+    os.environ.get("DASHBOARD_QSUBMIT_SCRIPTS") or
+    os.path.join(
+        os.path.dirname(os.path.realpath(__name__)),
+        '..dashboard/queue_jobs'
+        )
+    )

--- a/config/cluster.py
+++ b/config/cluster.py
@@ -1,0 +1,9 @@
+"""Configuration for job submission to a cluster.
+"""
+import os
+
+# Command to use when submitting to cluster.
+SUBMIT_COMMAND = os.environ.get("DASHBOARD_QSUBMIT_CMD") or "sbatch"
+
+# Options to always set during submission (e.g. QOS)
+SUBMIT_OPTIONS = os.environ.get("DASHBOARD_QSUBMIT_OPTIONS") or ""

--- a/config/cluster.py
+++ b/config/cluster.py
@@ -6,7 +6,7 @@ import os
 SUBMIT_COMMAND = os.environ.get("DASHBOARD_QSUBMIT_CMD") or "sbatch"
 
 # Options to always set during submission (e.g. QOS)
-SUBMIT_OPTIONS = os.environ.get("DASHBOARD_QSUBMIT_OPTIONS") or ""
+SUBMIT_OPTIONS = os.environ.get("DASHBOARD_QSUBMIT_OPTIONS") or "--chdir=/tmp/"
 
 # Job script location. If changed from dashboard/queue_jobs, the folder
 # must contain scripts matching the names of those in the original folder.

--- a/config/cluster.py
+++ b/config/cluster.py
@@ -14,6 +14,6 @@ SUBMIT_SCRIPTS = (
     os.environ.get("DASHBOARD_QSUBMIT_SCRIPTS") or
     os.path.join(
         os.path.dirname(os.path.realpath(__name__)),
-        '..dashboard/queue_jobs'
+        'dashboard/queue_jobs'
         )
     )

--- a/dashboard/blueprints/redcap/emails.py
+++ b/dashboard/blueprints/redcap/emails.py
@@ -11,10 +11,3 @@ def missing_session_data(session, study=None, dest_emails=None):
     body = "It has been 48hrs since a redcap scan completed survey was " \
            "received for {} but no scan data has been found.".format(session)
     send_email(subject, body, recipient=dest_emails)
-
-
-def download_succeeded(session, dest_emails=None):
-    subject = "{} successfully downloaded".format(session)
-    body = "Download of {} completed. Any post-download scripts that are " \
-           "configured will now be submitted.".format(session)
-    send_email(subject, body, recipient=dest_emails)

--- a/dashboard/blueprints/redcap/emails.py
+++ b/dashboard/blueprints/redcap/emails.py
@@ -11,3 +11,10 @@ def missing_session_data(session, study=None, dest_emails=None):
     body = "It has been 48hrs since a redcap scan completed survey was " \
            "received for {} but no scan data has been found.".format(session)
     send_email(subject, body, recipient=dest_emails)
+
+
+def download_succeeded(session, dest_emails=None):
+    subject = "{} successfully downloaded".format(session)
+    body = "Download of {} completed. Any post-download scripts that are " \
+           "configured will now be submitted.".format(session)
+    send_email(subject, body, recipient=dest_emails)

--- a/dashboard/blueprints/redcap/monitors.py
+++ b/dashboard/blueprints/redcap/monitors.py
@@ -130,7 +130,7 @@ def monitor_scan_download(session, end_time=None):
         if settings.post_download_script:
             submit_job(
                 settings.post_download_script,
-                [session.get_study().id, str(session)]
+                [study.id, str(session)]
             )
         return
 

--- a/dashboard/blueprints/redcap/monitors.py
+++ b/dashboard/blueprints/redcap/monitors.py
@@ -150,8 +150,8 @@ def check_download(name, num, end_time):
     session = Session.query.get((name, num))
     if not session:
         raise MonitorException(
-            "Monitored session {}_{:02d} is no longer in database, aborting "
-            "download attempt.".format(name, num))
+            "Monitored session {}_{} is no longer in database, aborting "
+            "download attempt.".format(name, str(num).zfill(2)))
 
     # 3. Submit a download job to queue
     cmd = [current_app.config['SUBMIT_COMMAND']]

--- a/dashboard/blueprints/redcap/monitors.py
+++ b/dashboard/blueprints/redcap/monitors.py
@@ -144,14 +144,6 @@ def monitor_scan_download(session, end_time=None):
         minutes=30
     )
 
-    # 3. Re-add self to scheduler first, with wakeup for 60 mins later.
-    # monitor_scan_download(session, end_time)
-
-    # 4. Submit job to download to the queue.
-
-    result = run(cmd, capture_output=True)
-
-    return
 
 def check_download(name, num, end_time):
     session = Session.query.get((name, num))

--- a/dashboard/blueprints/redcap/monitors.py
+++ b/dashboard/blueprints/redcap/monitors.py
@@ -6,7 +6,7 @@ on monitors and check functions.
 """
 from datetime import datetime, timedelta
 
-from .emails import missing_session_data
+from .emails import missing_session_data, download_succeeded
 from dashboard.monitors import add_monitor, get_emails
 from dashboard.models import Session, User
 from dashboard.exceptions import MonitorException
@@ -122,8 +122,11 @@ def monitor_scan_download(session, end_time=None):
         raise MonitorException("End time must be an instance of datetime. "
                                "Received type {}".format(type(end_time)))
 
+    study = session.get_study()
+
     if not session.missing_scans():
-        settings = session.get_site_settings()
+        settings = study.sites[session.site.name]
+        download_succeeded(session, study.get_staff_contacts())
         if settings.post_download_script:
             submit_job(
                 settings.post_download_script,

--- a/dashboard/blueprints/redcap/monitors.py
+++ b/dashboard/blueprints/redcap/monitors.py
@@ -161,7 +161,7 @@ def check_download(name, num, end_time):
 
     cmd.extend([
         join(current_app.config['SUBMIT_SCRIPTS'], 'data_download.sh'),
-        session.get_study(),
+        session.get_study().id,
         str(session)
     ])
 

--- a/dashboard/blueprints/redcap/monitors.py
+++ b/dashboard/blueprints/redcap/monitors.py
@@ -6,8 +6,6 @@ on monitors and check functions.
 """
 from datetime import datetime, timedelta
 
-from flask import current_app
-
 from .emails import missing_session_data
 from dashboard.monitors import add_monitor, get_emails
 from dashboard.models import Session, User

--- a/dashboard/blueprints/redcap/monitors.py
+++ b/dashboard/blueprints/redcap/monitors.py
@@ -6,7 +6,7 @@ on monitors and check functions.
 """
 from datetime import datetime, timedelta
 
-from .emails import missing_session_data, download_succeeded
+from .emails import missing_session_data
 from dashboard.monitors import add_monitor, get_emails
 from dashboard.models import Session, User
 from dashboard.exceptions import MonitorException
@@ -126,7 +126,6 @@ def monitor_scan_download(session, end_time=None):
 
     if not session.missing_scans():
         settings = study.sites[session.site.name]
-        download_succeeded(session, study.get_staff_contacts())
         if settings.post_download_script:
             submit_job(
                 settings.post_download_script,

--- a/dashboard/blueprints/redcap/utils.py
+++ b/dashboard/blueprints/redcap/utils.py
@@ -2,7 +2,6 @@
 
 import re
 import logging
-from subprocess import run
 
 from flask import url_for, flash, current_app
 from werkzeug.routing import RequestRedirect

--- a/dashboard/blueprints/redcap/utils.py
+++ b/dashboard/blueprints/redcap/utils.py
@@ -8,7 +8,7 @@ from flask import url_for, flash, current_app
 from werkzeug.routing import RequestRedirect
 import redcap as REDCAP
 
-from .monitors import monitor_scan_import
+from .monitors import monitor_scan_import, monitor_scan_download
 from dashboard.models import Session, Timepoint, RedcapRecord
 from dashboard.queries import get_study
 from dashboard.exceptions import RedcapException
@@ -87,7 +87,7 @@ def create_from_request(request):
     site_settings = study.sites[session.site.name]
 
     if site_settings.auto_download:
-        queue_download(session, new_job=True)
+        monitor_scan_download(session)
 
     return new_record
 

--- a/dashboard/blueprints/redcap/utils.py
+++ b/dashboard/blueprints/redcap/utils.py
@@ -3,8 +3,7 @@
 import re
 import logging
 
-from flask import url_for, flash
-from flask_login import current_user
+from flask import url_for, flash, current_app
 from werkzeug.routing import RequestRedirect
 import redcap as REDCAP
 
@@ -50,7 +49,7 @@ def create_from_request(request):
         logger.info("Record {} not completed. Ignoring".format(record))
         return
 
-    rc = REDCAP.Project(url + 'api/', current_user.config['REDCAP_TOKEN'])
+    rc = REDCAP.Project(url + 'api/', current_app.config['REDCAP_TOKEN'])
     server_record = rc.export_records([record])
 
     if len(server_record) < 0:

--- a/dashboard/blueprints/redcap/utils.py
+++ b/dashboard/blueprints/redcap/utils.py
@@ -126,29 +126,3 @@ def get_timepoint(ident):
             study = study[0].study
         timepoint = study.add_timepoint(ident)
     return timepoint
-
-
-def queue_download(session, new_job=False):
-    """Queue a job to download a session.
-
-    Adds a job to the scheduler that submits a queue job to download the
-    subject. The scheduler will resubmit this job every 30 minutes until
-    at least one scan has been added to the database for the session or
-    two days has passed.
-
-    Args:
-        session (:obj:`dashboard.models.Session`): A session object for the
-            scan to be downloaded.
-    """
-
-    # 1. Check if scans.missing() <- exit / finish if not
-    if not session.missing_scans():
-        # Submit post download jobs here
-        return
-
-    # 2. Grab the scheduler job...? Original submit date of job... ?
-    # 3. If current date >= 2 days from original submit time exit / finish
-    # 4. Submit queue job, re-add scheduler job with original date...
-    result = run(cmd, capture_output=True)
-
-    return

--- a/dashboard/blueprints/redcap/utils.py
+++ b/dashboard/blueprints/redcap/utils.py
@@ -85,7 +85,7 @@ def create_from_request(request):
     study = session.get_study()
     site_settings = study.sites[session.site.name]
 
-    if site_settings.auto_download:
+    if site_settings.download_script:
         monitor_scan_download(session)
 
     return new_record

--- a/dashboard/blueprints/redcap/views.py
+++ b/dashboard/blueprints/redcap/views.py
@@ -25,7 +25,7 @@ def redcap():
         logger.error('Failed creating redcap object. Reason: {}'.format(e))
         raise InvalidUsage(str(e), status_code=400)
 
-    return render_template('200.html'), 200
+    return 'Record successfully added', 200
 
 
 @rcap_bp.route('/redcap_redirect/<int:record_id>', methods=['GET'])

--- a/dashboard/models/models.py
+++ b/dashboard/models/models.py
@@ -1172,10 +1172,6 @@ class Session(db.Model):
     def get_study(self, study_id=None):
         return self.timepoint.get_study(study_id=study_id)
 
-    def get_site_settings(self, study_id=None):
-        study = self.get_study(study_id)
-        return study.sites[self.site.name]
-
     def add_scan(self, name, series, tag, description=None, source_id=None):
         scan = Scan(name, self.name, self.num, series, tag, description,
                     source_id)

--- a/dashboard/models/models.py
+++ b/dashboard/models/models.py
@@ -1165,6 +1165,10 @@ class Session(db.Model):
         self.reviewer_id = reviewer_id
         self.review_date = review_date
 
+    @property
+    def site(self):
+        return self.timepoint.site
+
     def get_study(self, study_id=None):
         return self.timepoint.get_study(study_id=study_id)
 
@@ -1960,6 +1964,11 @@ class StudySite(db.Model):
                         db.ForeignKey('sites.name'),
                         primary_key=True)
     uses_redcap = db.Column('uses_redcap', db.Boolean, default=False)
+    auto_download = db.Column(
+        'auto_download',
+        db.Boolean,
+        server_default="False"
+    )
     code = db.Column('code', db.String(32))
 
     # Need to specify the terms of the join to ensure users with

--- a/dashboard/models/models.py
+++ b/dashboard/models/models.py
@@ -1964,12 +1964,13 @@ class StudySite(db.Model):
                         db.ForeignKey('sites.name'),
                         primary_key=True)
     uses_redcap = db.Column('uses_redcap', db.Boolean, default=False)
+    code = db.Column('code', db.String(32))
     auto_download = db.Column(
         'auto_download',
         db.Boolean,
         server_default="False"
     )
-    code = db.Column('code', db.String(32))
+    post_download_step = db.Column('post_download_step', db.String(128))
 
     # Need to specify the terms of the join to ensure users with
     # access to all sites dont get left out of the list for a specific site

--- a/dashboard/models/models.py
+++ b/dashboard/models/models.py
@@ -1965,12 +1965,8 @@ class StudySite(db.Model):
                         primary_key=True)
     uses_redcap = db.Column('uses_redcap', db.Boolean, default=False)
     code = db.Column('code', db.String(32))
-    auto_download = db.Column(
-        'auto_download',
-        db.Boolean,
-        server_default="False"
-    )
-    post_download_step = db.Column('post_download_step', db.String(128))
+    download_script = db.Column('download_script', db.String(128))
+    post_download_script = db.Column('post_download_script', db.String(128))
 
     # Need to specify the terms of the join to ensure users with
     # access to all sites dont get left out of the list for a specific site

--- a/dashboard/models/models.py
+++ b/dashboard/models/models.py
@@ -1172,6 +1172,10 @@ class Session(db.Model):
     def get_study(self, study_id=None):
         return self.timepoint.get_study(study_id=study_id)
 
+    def get_site_settings(self, study_id=None):
+        study = self.get_study(study_id)
+        return study.sites[self.site.name]
+
     def add_scan(self, name, series, tag, description=None, source_id=None):
         scan = Scan(name, self.name, self.num, series, tag, description,
                     source_id)

--- a/dashboard/queue.py
+++ b/dashboard/queue.py
@@ -1,0 +1,49 @@
+"""Code used to interact with computing clusters.
+"""
+from os.path import join
+from subprocess import run, PIPE
+
+from flask import current_app
+
+logger = logging.getLogger(__name__)
+
+def submit_job(script, input_args=None, job_name=None, work_dir=None):
+    """Attempt to submit a job to the configured computing cluster.
+
+    Args:
+        script (str): The full path to the script to run as a queue job.
+        input_args (:obj:`list`, optional): A list of input arguments to give
+            the job script.
+        job_name (str, optional): The name to give the job.
+        work_dir (str, optional): The directory to use as the work dir.
+            A directory will be created in /tmp if none is given.
+    """
+    cmd = [current_app.config["SUBMIT_COMMAND"]]
+
+    if current_app.config["SUBMIT_OPTIONS"]:
+        cmd.append(current_app.config["SUBMIT_OPTIONS"])
+
+    cmd.append(script)
+
+    if input_args:
+        cmd.extend(input_args)
+
+    try:
+        # capture_output=True can be used only for python > 3.5
+        result = run(cmd, stdout=PIPE, stderr=PIPE)
+    except Exception:
+        logger.error(
+            "Failed to submit queue job '{}' with input args '{}'.".format(
+                script, input_args
+            )
+        )
+        raise
+
+    try:
+        result.check_returncode()
+    except CalledProcessError:
+        logger.error(
+            "An error occurred during submission of script '{}' with input "
+            "args '{}'.".format(script, input_args)
+        )
+        raise

--- a/dashboard/queue.py
+++ b/dashboard/queue.py
@@ -1,7 +1,7 @@
 """Code used to interact with computing clusters.
 """
 from os.path import join
-from subprocess import run, PIPE
+from subprocess import run, PIPE, CalledProcessError
 import logging
 
 from flask import current_app

--- a/dashboard/queue.py
+++ b/dashboard/queue.py
@@ -21,7 +21,7 @@ def submit_job(script, input_args=None):
     if current_app.config["SUBMIT_OPTIONS"]:
         cmd.append(current_app.config["SUBMIT_OPTIONS"])
 
-    cmd.append(join(current_app.config['SUBMIT_SCRIPTS'], script))
+    cmd.append(join(current_app.config["SUBMIT_SCRIPTS"], script))
 
     if input_args:
         cmd.extend(input_args)

--- a/dashboard/queue.py
+++ b/dashboard/queue.py
@@ -45,3 +45,5 @@ def submit_job(script, input_args=None):
             "args '{}'.".format(script, input_args)
         )
         raise
+
+    return result.stdout, result.stderr

--- a/dashboard/queue.py
+++ b/dashboard/queue.py
@@ -2,6 +2,7 @@
 """
 from os.path import join
 from subprocess import run, PIPE
+import logging
 
 from flask import current_app
 

--- a/dashboard/queue.py
+++ b/dashboard/queue.py
@@ -12,7 +12,7 @@ def submit_job(script, input_args=None):
     """Attempt to submit a job to the configured computing cluster.
 
     Args:
-        script (str): The full path to the script to run as a queue job.
+        script (str): The name of a script in the SUBMIT_SCRIPTS folder.
         input_args (:obj:`list`, optional): A list of input arguments to give
             the job script.
     """
@@ -21,7 +21,7 @@ def submit_job(script, input_args=None):
     if current_app.config["SUBMIT_OPTIONS"]:
         cmd.append(current_app.config["SUBMIT_OPTIONS"])
 
-    cmd.append(script)
+    cmd.append(join(current_app.config['SUBMIT_SCRIPTS'], script))
 
     if input_args:
         cmd.extend(input_args)

--- a/dashboard/queue.py
+++ b/dashboard/queue.py
@@ -8,16 +8,13 @@ from flask import current_app
 
 logger = logging.getLogger(__name__)
 
-def submit_job(script, input_args=None, job_name=None, work_dir=None):
+def submit_job(script, input_args=None):
     """Attempt to submit a job to the configured computing cluster.
 
     Args:
         script (str): The full path to the script to run as a queue job.
         input_args (:obj:`list`, optional): A list of input arguments to give
             the job script.
-        job_name (str, optional): The name to give the job.
-        work_dir (str, optional): The directory to use as the work dir.
-            A directory will be created in /tmp if none is given.
     """
     cmd = [current_app.config["SUBMIT_COMMAND"]]
 

--- a/dashboard/queue_jobs/data_download.sh
+++ b/dashboard/queue_jobs/data_download.sh
@@ -1,0 +1,14 @@
+#!/bin/bash -l
+#
+#SBATCH --job-name=download_session
+#SBATCH --ntasks=1
+#SBATCH --cores=1
+#SBATCH --time=01:00:00
+
+module load lab-code
+module load minc-toolkit/1.0.01
+
+study=$1
+subject=$2
+
+dm_xnat_extract.py ${study} ${subject}

--- a/migrations/versions/442e3abe5587_.py
+++ b/migrations/versions/442e3abe5587_.py
@@ -20,15 +20,15 @@ def upgrade():
     op.add_column(
         'study_sites',
         sa.Column(
-            'auto_download',
-            sa.Boolean(),
-            server_default='False',
+            'download_script',
+            sa.String(length=128),
+            nullable=True
         )
     )
     op.add_column(
         'study_sites',
         sa.Column(
-            'post_download_step',
+            'post_download_script',
             sa.String(length=128),
             nullable=True
         )
@@ -36,5 +36,5 @@ def upgrade():
 
 
 def downgrade():
-    op.drop_column('study_sites', 'post_download_step')
-    op.drop_column('study_sites', 'auto_download')
+    op.drop_column('study_sites', 'post_download_script')
+    op.drop_column('study_sites', 'download_script')

--- a/migrations/versions/442e3abe5587_.py
+++ b/migrations/versions/442e3abe5587_.py
@@ -1,5 +1,4 @@
-"""Add a column to indicate that sessions should be downloaded as soon as
-a redcap form comes in (and indicate there may be further pipelines to run).
+"""Add a columns to configure on demand downloading + post download processing.
 
 Revision ID: 442e3abe5587
 Revises: c5d321b34b54
@@ -26,7 +25,16 @@ def upgrade():
             server_default='False',
         )
     )
+    op.add_column(
+        'study_sites',
+        sa.Column(
+            'post_download_step',
+            sa.String(length=128),
+            nullable=True
+        )
+    )
 
 
 def downgrade():
+    op.drop_column('study_sites', 'post_download_step')
     op.drop_column('study_sites', 'auto_download')

--- a/migrations/versions/442e3abe5587_.py
+++ b/migrations/versions/442e3abe5587_.py
@@ -1,0 +1,32 @@
+"""Add a column to indicate that sessions should be downloaded as soon as
+a redcap form comes in (and indicate there may be further pipelines to run).
+
+Revision ID: 442e3abe5587
+Revises: c5d321b34b54
+Create Date: 2020-07-20 16:43:57.435851
+
+"""
+from alembic import op
+import sqlalchemy as sa
+
+
+# revision identifiers, used by Alembic.
+revision = '442e3abe5587'
+down_revision = 'c5d321b34b54'
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    op.add_column(
+        'study_sites',
+        sa.Column(
+            'auto_download',
+            sa.Boolean(),
+            server_default='False',
+        )
+    )
+
+
+def downgrade():
+    op.drop_column('study_sites', 'auto_download')


### PR DESCRIPTION
This adds two columns to the study_sites database table that can take the names of a download script and a post download script to submit to the queue. It also adds a monitor function to repeatedly re-submit the download script (for a max of 2 days) until scans have successfully been found and downloaded + launch the post download script on success.