### PR TITLE
Fix issues with viewing redcap URL

### DIFF
--- a/dashboard/blueprints/redcap/utils.py
+++ b/dashboard/blueprints/redcap/utils.py
@@ -50,10 +50,10 @@ def create_from_request(request):
         )
     except Exception as e:
         logger.info(
-             "Failed to find redcap config for record {} in project {} on "
-             "server {} with instrument {}. Exception - {}".format(
-                 record, project, url, instrument, e
-             )
+            "Failed to find redcap config for record {} in project {} on "
+            "server {} with instrument {}. Exception - {}".format(
+                record, project, url, instrument, e
+            )
         )
         return
 

--- a/dashboard/blueprints/redcap/utils.py
+++ b/dashboard/blueprints/redcap/utils.py
@@ -44,9 +44,18 @@ def create_from_request(request):
                               'required key. Found keys: {}'.format(
                                   list(request.form.keys())))
 
-    cfg = RedcapConfig.get_config(
-        url=url, project=project, instrument=instrument
-    )
+    try:
+        cfg = RedcapConfig.get_config(
+            url=url, project=project, instrument=instrument
+        )
+    except Exception as e:
+        logger.info(
+             "Failed to find redcap config for record {} in project {} on "
+             "server {} with instrument {}. Exception - {}".format(
+                 record, project, url, instrument, e
+             )
+        )
+        return
 
     if request.form[cfg.completed_field] != cfg.completed_value:
         logger.info("Record {} not completed. Ignoring".format(record))

--- a/dashboard/models/models.py
+++ b/dashboard/models/models.py
@@ -1822,6 +1822,22 @@ class RedcapRecord(db.Model):
         self.date = date
         self.redcap_version = version
 
+    @property
+    def url(self):
+        return self.config.url
+
+    @property
+    def project(self):
+        return self.config.project
+
+    @property
+    def instrument(self):
+        return self.config.instrument
+
+    @property
+    def redcap_version(self):
+        return self.config.redcap_version
+
     def __repr__(self):
         return "<RedcapRecord {}: record {}>".format(self.id, self.record)
 


### PR DESCRIPTION
I accidentally broke the url to view redcap surveys, but this fixes it by re-exposing those config values on the record itself. It also makes the dashboard less spammy when there are multiple instruments configured for a survey that sends DETs.