### PR TITLE
[FIX] Make it easier to find surveys with bad session IDs / no ID

### DIFF
--- a/dashboard/blueprints/redcap/utils.py
+++ b/dashboard/blueprints/redcap/utils.py
@@ -94,7 +94,14 @@ def create_from_request(request):
                               'required field. Found keys: {}'.format(
                                   record, list(server_record.keys())))
 
-    session = set_session(session_name)
+    try:
+        session = set_session(session_name)
+    except Exception as e:
+        raise RedcapException(
+            "Failed finding session for record {} from project {} on server "
+            "{}. Reason: {}".format(record, project, url, e)
+        )
+
     try:
         new_record = session.add_redcap(
             record, date, config=cfg.id, rc_user=redcap_user, comment=comment


### PR DESCRIPTION
This is in response to the error messages today. I think a redcap survey was saved without the ID filled in, so the error message left no indications of where to look to fix the error.