### PR TITLE
[FIX] Stop the 'unparseable request' exceptions for some redcap DETs

### DIFF
--- a/dashboard/blueprints/redcap/utils.py
+++ b/dashboard/blueprints/redcap/utils.py
@@ -57,7 +57,9 @@ def create_from_request(request):
         )
         return
 
-    if request.form[cfg.completed_field] != cfg.completed_value:
+    if (cfg.completed_field in request.form
+            and request.form[cfg.completed_field] != cfg.completed_value):
+        # Check if complete before pulling whole record
         logger.info("Record {} not completed. Ignoring".format(record))
         return
 
@@ -81,6 +83,12 @@ def create_from_request(request):
                               '{}'.format(len(server_record), record, url))
 
     server_record = server_record[0]
+
+    if (cfg.completed_field not in request.form
+            and server_record[cfg.completed_field] != cfg.completed_value):
+        # Check when the 'completed' field wasnt present in the DET
+        logger.info("Record {} not completed. Ignoring".format(record))
+        return
 
     try:
         date = server_record[cfg.date_field]

--- a/dashboard/blueprints/redcap/utils.py
+++ b/dashboard/blueprints/redcap/utils.py
@@ -57,8 +57,8 @@ def create_from_request(request):
         )
         return
 
-    if (cfg.completed_field in request.form
-            and request.form[cfg.completed_field] != cfg.completed_value):
+    if (cfg.completed_field in request.form and
+            request.form[cfg.completed_field] != cfg.completed_value):
         # Check if complete before pulling whole record
         logger.info("Record {} not completed. Ignoring".format(record))
         return
@@ -84,8 +84,8 @@ def create_from_request(request):
 
     server_record = server_record[0]
 
-    if (cfg.completed_field not in request.form
-            and server_record[cfg.completed_field] != cfg.completed_value):
+    if (cfg.completed_field not in request.form and
+            server_record[cfg.completed_field] != cfg.completed_value):
         # Check when the 'completed' field wasnt present in the DET
         logger.info("Record {} not completed. Ignoring".format(record))
         return

--- a/dashboard/blueprints/redcap/views.py
+++ b/dashboard/blueprints/redcap/views.py
@@ -17,8 +17,6 @@ def redcap():
     A redcap server can send a notification to this URL when a survey is saved
     and the record will be retrieved and saved to the database.
     """
-    logger.debug('Received keys {} from REDcap from URL {}'.format(
-        list(request.form.keys()), request.form['project_url']))
     try:
         utils.create_from_request(request)
     except Exception as e:


### PR DESCRIPTION
It turns out that only a very small subset of survey keys are included in the DET and so when users try to choose a 'completed' field it often is left out and causes uncaught key errors preventing the survey from being pulled in. This fixes that issue and also silences the very spammy and unhelpful debug message in the redcap view