### PR TITLE
[FIX] Make delete propagate from timepoint too

### DIFF
--- a/dashboard/models/models.py
+++ b/dashboard/models/models.py
@@ -1024,6 +1024,8 @@ class Timepoint(db.Model):
         This will cascade and also delete any records that reference
         the current timepoint, so be careful :)
         """
+        for num in self.sessions:
+            self.sessions[num].delete()
         db.session.delete(self)
         db.session.commit()
 


### PR DESCRIPTION
Oops, brain fart. I forgot to update timepoint deletion too, so redcap records would still get stranded if the timepoint was deleted rather than an individual session. This fixes that too. 